### PR TITLE
Update sdk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.31
+          version: v1.34.0
 
   excludeFmtErrorf:
     name: exclude fmt.Errorf
@@ -141,7 +141,7 @@ jobs:
       - name: Build container
         run: docker build .
       - name: Run tests
-        run: docker run --rm $(docker build -q . --target test)
+        run: docker run --privileged --rm $(docker build -q . --target test)
       - name: Find merged PR
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: jwalton/gh-find-current-pr@v1
@@ -192,7 +192,7 @@ jobs:
     name: automerge
     runs-on: ubuntu-latest
     needs:
-      - update-integration-k8s-kind
+      - update-deployments-k8s
     if: github.actor == 'nsmbot' && github.base_ref == 'master' && github.event_name == 'pull_request'
     steps:
       - name: Check out the code
@@ -209,10 +209,8 @@ jobs:
           GITHUB_LOGIN: nsmbot
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  update-integration-k8s-kind:
-    needs:
-      - pushImage
-    name: Update integration-k8s-kind
+  update-deployments-k8s:
+    name: Update deployments-k8s
     runs-on: ubuntu-latest
     if: github.repository != 'networkservicemesh/cmd-template' && github.actor == 'nsmbot' && github.base_ref == 'master' && github.event_name == 'pull_request'
     steps:
@@ -222,23 +220,16 @@ jobs:
           path: ${{ github.repository }}
           repository: ${{ github.repository }}
           token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
-      - name: Create branch name
-        working-directory: ${{ github.repository }}
-        run: |
-          diff=$(git diff --name-only)
-          BRANCH_NAME="${{ github.event.repository.name }}"
-          if [[ $(grep "go.mod" <<< "${diff}") && $(grep "" -c <<< "${diff}") == 2 ]]; then
-            sdkPattern="github.com\/networkservicemesh\/sdk "
-            sdkVersion=$(grep --regexp "${sdkPattern}" go.mod)
-            BRANCH_NAME="${sdkVersion:${#sdkPattern}}"
-          else
-            {
-              git push origin --delete update/"${BRANCH_NAME}"
-            } || {
-              echo Branch update/"${BRANCH_NAME}" is already deleted
-            }
-          fi;
-          echo BRANCH_NAME=${BRANCH_NAME} >> $GITHUB_ENV
+      - uses: benjlevesque/short-sha@v1.2
+        id: short-sha
+        with:
+          length: 8
+      - name: Checkout networkservicemesh/deployments-k8s
+        uses: actions/checkout@v2
+        with:
+          path: networkservicemesh/deployments-k8s
+          repository: networkservicemesh/deployments-k8s
+          token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
       - name: Create commit message
         working-directory: ${{ github.repository }}
         run: |
@@ -250,25 +241,15 @@ jobs:
           git log -1 >> /tmp/commit-message
           echo "Commit Message:"
           cat /tmp/commit-message
-      - name: Checkout networkservicemesh/integration-k8s-kind
-        uses: actions/checkout@v2
-        with:
-          path: networkservicemesh/integration-k8s-kind
-          repository: networkservicemesh/integration-k8s-kind
-          token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
-      - uses: benjlevesque/short-sha@v1.2
-        id: short-sha
-        with:
-          length: 8
       - name: Find and Replace version
         uses: jacobtomlinson/gha-find-replace@master
         with:
           find: "${{ github.event.repository.name }}:.*\n"
           replace: "${{ github.event.repository.name }}:${{ steps.short-sha.outputs.sha }}\n"
-      - name: Push update to the integration-k8s-kind
-        working-directory: networkservicemesh/integration-k8s-kind
+      - name: Push update to the deployments-k8s
+        working-directory: networkservicemesh/deployments-k8s
         run: |
-          echo Starting to update repositotry integration-k8s-kind
+          echo Starting to update repositotry deployments-k8s
           git add -- .
           if ! [ -n "$(git diff --cached --exit-code)" ]; then
             echo Repository already up to date
@@ -277,8 +258,5 @@ jobs:
           git config --global user.email "nsmbot@networkservicmesh.io"
           git config --global user.name "NSMBot"
           git commit -s -F /tmp/commit-message
-          git checkout -b update/"${BRANCH_NAME}"
-          while [ $(git push origin update/"${BRANCH_NAME}") ]; do
-            git fetch origin update/"${BRANCH_NAME}"
-            git rebase origin/update/"${BRANCH_NAME}"
-          done
+          git checkout -b update/${{ github.repository }}
+          git push -f origin update/${{ github.repository }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,12 +8,9 @@ linters-settings:
   goheader:
     template-path: ".license/template.txt"
     values:
-      const:
-        year: 2020
       regexp:
-        year-range: ((\d\d\d\d-{{year}})|({{year}}))
         company: .*
-        copyright-holder: Copyright \(c\) {{year-range}} {{company}}\n\n
+        copyright-holder: Copyright \(c\) ({{year-range}}) {{company}}\n\n
         copyright-holders: ({{copyright-holder}})+
   errcheck:
     check-type-assertions: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,4 @@ CMD dlv -l :40000 --headless=true --api-version=2 test -test.v ./...
 
 FROM alpine as runtime
 COPY --from=build /bin/app /bin/app
-COPY --from=build /bin/dlv /bin/dlv
 CMD /bin/app

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/edwarnicke/grpcfd v0.0.0-20200920223154-d5b6e1f19bd0
 	github.com/golang/protobuf v1.4.3
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/networkservicemesh/api v0.0.0-20201117093615-ae6039374f31
-	github.com/networkservicemesh/sdk v0.0.0-20201127064728-76a93c05a11e
+	github.com/networkservicemesh/api v0.0.0-20201229064852-7d9663ff679a
+	github.com/networkservicemesh/sdk v0.0.0-20201229104015-7ba857b11d53
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spiffe/go-spiffe/v2 v2.0.0-alpha.4.0.20200528145730-dc11d0c74e85

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/edwarnicke/grpcfd v0.0.0-20200920223154-d5b6e1f19bd0 h1:FHjcIM6YU8DnC
 github.com/edwarnicke/grpcfd v0.0.0-20200920223154-d5b6e1f19bd0/go.mod h1:rHihB9YvNMixz8rS+ZbwosI2kj65VLkeyYAI2M+/cGA=
 github.com/edwarnicke/serialize v0.0.0-20200705214914-ebc43080eecf h1:/lViRfaDxKINb2X6kOR3EJKJGR+MxUvqfgtYt5nh+qc=
 github.com/edwarnicke/serialize v0.0.0-20200705214914-ebc43080eecf/go.mod h1:XvbCO/QGsl3X8RzjBMoRpkm54FIAZH5ChK2j+aox7pw=
+github.com/edwarnicke/serialize v1.0.7 h1:geX8vmyu8Ij2S5fFIXjy9gBDkKxXnrMIzMoDvV0Ddac=
+github.com/edwarnicke/serialize v1.0.7/go.mod h1:y79KgU2P7ALH/4j37uTSIdNavHFNttqN7pzO6Y8B2aw=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -283,10 +285,10 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nats-io/stan.go v0.6.0/go.mod h1:eIcD5bi3pqbHT/xIIvXMwvzXYElgouBvaVRftaE+eac=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
-github.com/networkservicemesh/api v0.0.0-20201117093615-ae6039374f31 h1:z5a+28GCNiopGCS1GY2eoTEUf47fbpsSs4eVC0rsgW0=
-github.com/networkservicemesh/api v0.0.0-20201117093615-ae6039374f31/go.mod h1:qvxdY1Zt4QTtiG+uH1XmjpegeHjlt5Jj4A8iK55iJPI=
-github.com/networkservicemesh/sdk v0.0.0-20201127064728-76a93c05a11e h1:RWAUqFBzsy6ZlvYjAr9cL/JQnmNi+2ZfUQVebxjWb4g=
-github.com/networkservicemesh/sdk v0.0.0-20201127064728-76a93c05a11e/go.mod h1:VXfLAFP8/522hnATXPNGCH2/oy9Jb6KOXZhiACBEb04=
+github.com/networkservicemesh/api v0.0.0-20201229064852-7d9663ff679a h1:kVCdG/y5MxZUKye7G+n7Sre7afg6fTa68VMJIYgLWB8=
+github.com/networkservicemesh/api v0.0.0-20201229064852-7d9663ff679a/go.mod h1:qvxdY1Zt4QTtiG+uH1XmjpegeHjlt5Jj4A8iK55iJPI=
+github.com/networkservicemesh/sdk v0.0.0-20201229104015-7ba857b11d53 h1:O2rejKoSTaLm3avhEkPyZ5NEW1BVbwN2fb9+ByrccUk=
+github.com/networkservicemesh/sdk v0.0.0-20201229104015-7ba857b11d53/go.mod h1:Zpdjr7DejxfXXbZJyCFkJGwj4zG/vOsGJsRu8Raf3nw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.0.0-20200811152831-6cf413ae40e0/go.mod h1:wBEpHwM2OdmeNpdCvRPUlkEbBuaFmcK4Wv8Q7FuGW3c=

--- a/internal/imports/imports.go
+++ b/internal/imports/imports.go
@@ -22,7 +22,7 @@ import (
 	_ "github.com/networkservicemesh/sdk/pkg/registry/common/setid"
 	_ "github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
 	_ "github.com/networkservicemesh/sdk/pkg/registry/core/chain"
-	_ "github.com/networkservicemesh/sdk/pkg/registry/memory"
+	_ "github.com/networkservicemesh/sdk/pkg/registry/common/memory"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/debug"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/jaeger"

--- a/suite_setup_test.go
+++ b/suite_setup_test.go
@@ -36,11 +36,11 @@ import (
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/expire"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
 	registryrecvfd "github.com/networkservicemesh/sdk/pkg/registry/common/recvfd"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/setid"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
 	registrychain "github.com/networkservicemesh/sdk/pkg/registry/core/chain"
-	"github.com/networkservicemesh/sdk/pkg/registry/memory"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/spire"
 )
@@ -102,7 +102,7 @@ func (f *TestSuite) SetupSuite() {
 	memrg := memory.NewNetworkServiceEndpointRegistryServer()
 	registryServer := registrychain.NewNetworkServiceEndpointRegistryServer(
 		setid.NewNetworkServiceEndpointRegistryServer(),
-		expire.NewNetworkServiceEndpointRegistryServer(),
+		expire.NewNetworkServiceEndpointRegistryServer(24*time.Hour),
 		registryrecvfd.NewNetworkServiceEndpointRegistryServer(),
 		memrg,
 	)


### PR DESCRIPTION
# Fixes
1. `sdk` fails to update `cmd-nse-vfio` because of `registry/memory` -> `registry/common/memory` move.
2. https://github.com/networkservicemesh/cmd-nse-vfio/issues/2
3. Manually updates CI files to the current `cmd-template` version.