### PR TITLE
qfix: add missed sendfd registry client

### DIFF
--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/networkservicemesh/sdk/pkg/registry/common/expire"
 	_ "github.com/networkservicemesh/sdk/pkg/registry/common/memory"
 	_ "github.com/networkservicemesh/sdk/pkg/registry/common/recvfd"
+	_ "github.com/networkservicemesh/sdk/pkg/registry/common/sendfd"
 	_ "github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
 	_ "github.com/networkservicemesh/sdk/pkg/registry/core/chain"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/debug"

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/sendfd"
 	"github.com/networkservicemesh/sdk/pkg/tools/debug"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
@@ -206,7 +207,14 @@ func main() {
 		}
 	}
 
-	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, &cfg.ConnectTo, registryclient.WithDialOptions(clientOptions...))
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(
+		ctx,
+		&cfg.ConnectTo,
+		registryclient.WithDialOptions(clientOptions...),
+		registryclient.WithNSEAdditionalFunctionality(
+			sendfd.NewNetworkServiceEndpointRegistryClient(),
+		),
+	)
 	nse, err := nseRegistryClient.Register(ctx, registryEndpoint(listenOn, cfg))
 	if err != nil {
 		log.FromContext(ctx).Fatalf("unable to register nse %+v", err)


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

We've removed `sendfd` from default registry/chains because NSM can be used in non-k8s systems. Now we need to add for each k8s nse app `sendfd` as additional functionality.

Fixes https://github.com/networkservicemesh/integration-k8s-packet/pull/225