### PR TITLE
Add RegisterService flag

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,8 @@ type Config struct {
 	LogLevel              string        `default:"INFO" desc:"Log level" split_words:"true"`
 	OpenTelemetryEndpoint string        `default:"otel-collector.observability.svc.cluster.local:4317" desc:"OpenTelemetry Collector Endpoint"`
 
-	Services []ServiceConfig `default:"" desc:"list of supported services"`
+	ServiceNames    []ServiceConfig `default:"" desc:"list of supported services" split_words:"true"`
+	RegisterService bool            `default:"true" desc:"if true then registers network service on startup" split_words:"true"`
 }
 
 // Process prints and processes env to config

--- a/internal/networkservice/mapserver/server.go
+++ b/internal/networkservice/mapserver/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2022 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -42,11 +42,11 @@ type entry struct {
 // NewServer returns a new `network service -> { MAC, VLAN }` mapping server chain element
 func NewServer(cfg *config.Config) networkservice.NetworkServiceServer {
 	s := &mapServer{
-		entries: make(map[string]*entry, len(cfg.Services)),
+		entries: make(map[string]*entry, len(cfg.ServiceNames)),
 	}
 
-	for i := range cfg.Services {
-		service := &cfg.Services[i]
+	for i := range cfg.ServiceNames {
+		service := &cfg.ServiceNames[i]
 		s.entries[service.Name] = &entry{
 			macAddr: service.MACAddr,
 			vlanTag: service.VLANTag,


### PR DESCRIPTION
This PR adds `RegisterService` flag to be able to not register a service

We also replace `Services` with `ServiceNames` to be consistent with other nse repositories 

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>