### PR TITLE
Ability to parse the configuration without additional parameters

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,7 +83,7 @@ func (s *ServiceConfig) UnmarshalBinary(bytes []byte) (err error) {
 
 	split = strings.Split(text, "{")
 	if len(split) < 2 {
-		return errors.Errorf("invalid format: %s", text)
+		return s.validate()
 	}
 
 	split = strings.Split(split[1], "}")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,4 +45,12 @@ func TestServiceConfig_UnmarshalBinary(t *testing.T) {
 		Name:    "pingpong",
 		VLANTag: 1111,
 	}, cfg)
+
+	cfg = new(config.ServiceConfig)
+	err = cfg.UnmarshalBinary([]byte("pingpong"))
+	require.NoError(t, err)
+
+	require.Equal(t, &config.ServiceConfig{
+		Name: "pingpong",
+	}, cfg)
 }


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/sdk-sriov/issues/489